### PR TITLE
모바일/데스크탑 분리 및 모바일 상세 뒤로가기 반영

### DIFF
--- a/src/app/_components/footer/Index.tsx
+++ b/src/app/_components/footer/Index.tsx
@@ -1,0 +1,21 @@
+'use client';
+import React from 'react';
+import { faArrowLeft } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { useRouter } from 'next/navigation';
+
+interface FooterProps {
+    children?: React.ReactNode;
+}
+
+const Footer: React.FC<FooterProps> = ({ children }) => {
+    const router = useRouter();
+    return (
+        <div className="footer-wrapper">
+            <FontAwesomeIcon icon={faArrowLeft} style={{ marginRight: '5px' }} onClick={() => router.back()} />
+            <>{children}</>
+        </div>
+    );
+};
+
+export default Footer;

--- a/src/app/_components/header/Header.tsx
+++ b/src/app/_components/header/Header.tsx
@@ -1,0 +1,28 @@
+import { faArrowLeft, faBars, faHouse } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { usePathname, useRouter } from 'next/navigation';
+import React, { useEffect, useState } from 'react';
+import { isMobile } from 'react-device-detect';
+
+const Header = () => {
+    const router = useRouter();
+    const pathname = usePathname();
+    const [isClient, setIsClient] = useState(false);
+
+    useEffect(() => {
+        setIsClient(isMobile); // 클라이언트에서만 true로 설정
+    }, []);
+    return (
+        <div className="header">
+            <div className="left-wrap">
+                <FontAwesomeIcon icon={faBars} size="2x" color="white" />
+                <FontAwesomeIcon icon={faHouse} size="2x" color="white" onClick={() => router.push('/')} />
+            </div>
+            <div className="right-wrap">
+                <input />
+            </div>
+        </div>
+    );
+};
+
+export default Header;

--- a/src/app/_components/root/Desktop.tsx
+++ b/src/app/_components/root/Desktop.tsx
@@ -2,7 +2,7 @@
 
 import { usePathname } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
-import Header from './_components/header/Header';
+import Header from '../header/Header';
 export default function SmoothScroll({ children }: { children: React.ReactNode }) {
     const pathname = usePathname();
     const scrollRef = useRef<HTMLDivElement>(null);
@@ -63,6 +63,8 @@ export default function SmoothScroll({ children }: { children: React.ReactNode }
             window.removeEventListener('beforeunload', saveScrollPosition); // 이벤트 리스너 제거
         };
     }, [pathname]);
+
+    console.log(pathname, '<pathname');
 
     return (
         <>

--- a/src/app/_components/root/Mobile.tsx
+++ b/src/app/_components/root/Mobile.tsx
@@ -1,0 +1,21 @@
+// front/src/app/_components/root/Mobile.tsx
+import { usePathname } from 'next/navigation';
+import React, { ReactNode } from 'react';
+import Header from '../header/Header';
+
+interface MobileProps {
+    children: ReactNode;
+}
+
+const Mobile: React.FC<MobileProps> = ({ children }) => {
+    const pathname = usePathname();
+
+    return (
+        <>
+            {pathname !== '/' && <Header />}
+            {children}
+        </>
+    );
+};
+
+export default Mobile;

--- a/src/app/_components/root/index.tsx
+++ b/src/app/_components/root/index.tsx
@@ -1,0 +1,27 @@
+'use client';
+// front/src/app/_components/root/index.tsx
+import React, { useEffect, useState, ReactNode } from 'react';
+import { isMobile } from 'react-device-detect';
+import Mobile from './Mobile';
+import Desktop from './Desktop';
+
+interface RootProps {
+    children: ReactNode;
+}
+
+const Root: React.FC<RootProps> = ({ children }) => {
+    const [isClient, setIsClient] = useState('');
+
+    useEffect(() => {
+        setIsClient(isMobile ? 'mobile' : 'desktop');
+    }, []);
+
+    return (
+        <div>
+            {isClient === 'mobile' && <Mobile>{children}</Mobile>}
+            {isClient === 'desktop' && <Desktop>{children}</Desktop>}
+        </div>
+    );
+};
+
+export default Root;

--- a/src/app/_styles/_css/common.scss
+++ b/src/app/_styles/_css/common.scss
@@ -1,17 +1,18 @@
 @import 'locomotive-scroll/dist/locomotive-scroll.css';
+@media only screen and (min-width: 681px) {
+    /* 기본 스타일 재설정 */
+    html.has-scroll-smooth {
+        overflow: hidden;
+    }
 
-/* 기본 스타일 재설정 */
-html.has-scroll-smooth {
-    overflow: hidden;
-}
-
-.locomotive-scroll {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    overflow: hidden;
+    .locomotive-scroll {
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        overflow: hidden;
+    }
 }
 
 body {
@@ -59,11 +60,13 @@ button {
     }
 }
 
-html,
-body {
-    height: 100%; /* 전체 높이 설정 */
-    margin: 0; /* 기본 마진 제거 */
-    overflow: hidden; /* Locomotive Scroll이 스크롤을 관리하므로 숨김 */
+@media only screen and (min-width: 681px) {
+    html,
+    body {
+        height: 100%; /* 전체 높이 설정 */
+        margin: 0; /* 기본 마진 제거 */
+        overflow: hidden; /* Locomotive Scroll이 스크롤을 관리하므로 숨김 */
+    }
 }
 
 .header {
@@ -92,6 +95,9 @@ body {
         input {
             height: 30px;
             width: 180px;
+            @media only screen and (max-width: 680px) {
+                width: 150px !important;
+            }
             border-radius: 5px;
             padding: 0 10px;
         }
@@ -100,4 +106,30 @@ body {
 .footer {
     height: 100px;
     width: 100px;
+}
+
+.footer-wrapper {
+    position: fixed;
+    width: 100%;
+    height: 50px;
+    bottom: 0;
+    background-color: black;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    color: white;
+    > div,
+    > svg {
+        margin: 0 20px;
+    }
+    .likes_cmt {
+        display: flex;
+        align-items: center;
+        > div {
+            margin: 0 10px;
+            > svg {
+                margin-right: 5px;
+            }
+        }
+    }
 }

--- a/src/app/_styles/_css/component.scss
+++ b/src/app/_styles/_css/component.scss
@@ -49,6 +49,9 @@
                 }
             }
         }
+        .just-view {
+            text-decoration: underline;
+        }
     }
 }
 
@@ -168,9 +171,6 @@
 
 .detail-wrapper {
     width: 90vw;
-    @media only screen and (max-width: 680px) {
-        width: 80vw !important;
-    }
     margin: 50px auto;
     border-radius: 10px;
     background-color: white;
@@ -179,6 +179,11 @@
     flex-direction: column;
     padding: 50px 20px;
     margin-bottom: 100px;
+    @media only screen and (max-width: 680px) {
+        width: 80vw !important;
+        margin: 30px auto;
+        margin-bottom: 100px;
+    }
     .category {
         color: var(--gray);
         font-style: italic;
@@ -186,14 +191,27 @@
     }
     .title {
         margin: 10px 0;
+        text-align: center;
+        @media only screen and (max-width: 680px) {
+            font-size: 30px;
+        }
+    }
+    .views {
+        text-align: left;
     }
     .info-wrap {
         display: flex;
         justify-content: flex-end;
+        @media only screen and (max-width: 680px) {
+            justify-content: center;
+        }
         align-items: center;
         margin-top: 10px;
         width: 100%;
         > p {
+            @media only screen and (max-width: 680px) {
+                width: auto !important;
+            }
             width: 150px;
             font-size: 15px;
             color: var(--gray);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import './_styles/_css/reset.scss';
 import './_styles/_css/component.scss';
 import SmoothScroll from './SmoothScroll';
 import { useEffect } from 'react';
+import Root from './_components/root';
 
 const geistSans = localFont({
     src: './_fonts/GeistVF.woff',
@@ -32,7 +33,7 @@ export default function RootLayout({
     return (
         <html lang="en">
             <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-                <SmoothScroll>{children}</SmoothScroll>
+                <Root>{children}</Root>
             </body>
         </html>
     );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -27,6 +27,14 @@ export default function Home() {
                     >
                         Register
                     </button>
+                    <p
+                        className="just-view"
+                        onClick={() => {
+                            router.push('/list');
+                        }}
+                    >
+                        Just View
+                    </p>
                 </div>
             </div>
         </div>

--- a/src/app/post/page.tsx
+++ b/src/app/post/page.tsx
@@ -4,67 +4,83 @@ import { useEffect, useState, Suspense } from 'react';
 import { PostDetail } from '../../../type';
 import API from '../_apis';
 import { useSearchParams } from 'next/navigation';
+import Footer from '../_components/footer/Index';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faComment, faHeart } from '@fortawesome/free-solid-svg-icons';
 
 const PostPageContent = () => {
-  const [post, setPost] = useState<PostDetail | null>(null);
-  const [loading, setLoading] = useState(true);
-  const searchParams = useSearchParams();
-  const postId = searchParams.get('id'); // URL 쿼리 파라미터에서 ID 가져오기
+    const [post, setPost] = useState<PostDetail | null>(null);
+    const [loading, setLoading] = useState(true);
+    const searchParams = useSearchParams();
+    const postId = searchParams.get('id'); // URL 쿼리 파라미터에서 ID 가져오기
 
-  useEffect(() => {
-    const fetchPost = async () => {
-      if (!postId) {
-        console.error('Post ID is missing');
-        setLoading(false);
-        return;
-      }
+    useEffect(() => {
+        const fetchPost = async () => {
+            if (!postId) {
+                console.error('Post ID is missing');
+                setLoading(false);
+                return;
+            }
 
-      try {
-        const response = await API.post.getPostDetail(postId); // ID에 해당하는 포스트 데이터 가져오기
-        setPost(response);
-      } catch (error) {
-        console.error('Error fetching post:', error);
-      } finally {
-        setLoading(false);
-      }
-    };
+            try {
+                const response = await API.post.getPostDetail(postId); // ID에 해당하는 포스트 데이터 가져오기
+                setPost(response);
+            } catch (error) {
+                console.error('Error fetching post:', error);
+            } finally {
+                setLoading(false);
+            }
+        };
 
-    fetchPost();
-  }, [postId]);
+        fetchPost();
+    }, [postId]);
 
-  if (loading) {
-    return <div>Loading...</div>; // 로딩 중 표시
-  }
+    if (loading) {
+        return <div>Loading...</div>; // 로딩 중 표시
+    }
 
-  if (!post) {
-    return <div>Post not found</div>; // 포스트가 없을 경우 표시
-  }
+    if (!post) {
+        return <div>Post not found</div>; // 포스트가 없을 경우 표시
+    }
 
-  return (
-    <div className="detail-wrapper">
-      <p className="category">{post.category.categoryName}</p>
-      <h2 className="title">{post.title}</h2>
-      <div className="info-wrap">
-        <p className="date">{post.date}</p>
-        <span className="separator">|</span> {/* 구분자 추가 */}
-        <p className="views">조회수 {post.views}</p>
-      </div>
-      <div
-        className="content"
-        dangerouslySetInnerHTML={{ __html: post.contents }}
-      />
-      {/* <p>작성자: {post.creator.name}</p> */}
-      {/* <p>조회수: {post.views}</p> */}
-    </div>
-  );
+    return (
+        <>
+            <div className="detail-wrapper">
+                <p className="category">{post.category.categoryName}</p>
+                <h2 className="title">{post.title}</h2>
+                <div className="info-wrap">
+                    <p className="date">{post.date}</p>
+                    <span className="separator">|</span>
+                    <p className="views">조회수 {post.views}</p>
+                </div>
+                <div className="content" dangerouslySetInnerHTML={{ __html: post.contents }} />
+            </div>
+        </>
+    );
 };
 
 const PostPage = () => {
-  return (
-    <Suspense fallback={<div>Loading...</div>}>
-      <PostPageContent />
-    </Suspense>
-  );
+    return (
+        <>
+            <Suspense fallback={<div>Loading...</div>}>
+                <PostPageContent />
+                <Footer>
+                    <div className="right-wrap">
+                        <p className="likes_cmt">
+                            <div className="likes">
+                                <FontAwesomeIcon icon={faHeart} />
+                                {1}
+                            </div>
+                            <div className="cmt">
+                                <FontAwesomeIcon icon={faComment} />
+                                {2}
+                            </div>
+                        </p>
+                    </div>
+                </Footer>
+            </Suspense>
+        </>
+    );
 };
 
 export default PostPage;


### PR DESCRIPTION
모바일 및 데스크탑 locomotive-scroll 분리

- 모바일은 기본scroll이 더 UX 및 CSS유지보수 차원에서 좋다고 판단하여 locaomotive-scroll분리
- 모바일은 상세페이지에서 헤더 및 푸터(뒤로가기, 댓글/좋아요)가 고정되어 노출되도록 함
- 피시는 해당작업중 푸터는 불필요하다 느껴 분기처리
- 페이지 첫 로드시 layout에서 장치를 감지해서 mobile이면 locomotive를 제거하여 UI노출. desktop의 경우 locomotive안에서 children 컴포넌트를 노출하여 scroll 모션을 동작시킴